### PR TITLE
fix: support @tanstack/db 0.6.x `From` union types

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,2 +1,0 @@
-allowBuilds:
-  esbuild: set this to true or false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,2 @@
+allowBuilds:
+  esbuild: set this to true or false

--- a/src/query-once.ts
+++ b/src/query-once.ts
@@ -66,11 +66,17 @@ function resolveFrom(from: SerializedFrom): {
   if (from.type === "table") {
     return { tableName: from.name, wheres: [] }
   }
-  const inner = resolveFrom(from.query.from)
-  return {
-    tableName: inner.tableName,
-    wheres: [...inner.wheres, ...(from.query.where ?? [])],
+  if (from.type === "subquery") {
+    const inner = resolveFrom(from.query.from)
+    return {
+      tableName: inner.tableName,
+      wheres: [...inner.wheres, ...(from.query.where ?? [])],
+    }
   }
+  // union / unionAll have no single base table to push to PostgREST
+  throw new Error(
+    `Cannot push a ${from.type} query to PostgREST; unions are not supported in queryOnce`
+  )
 }
 
 // ── Select string building ──────────────────────────────────────────

--- a/src/serialize.ts
+++ b/src/serialize.ts
@@ -24,6 +24,8 @@ export interface SerializedIncludesSubquery {
 export type SerializedFrom =
   | { type: `table`; name: string; alias: string }
   | { type: `subquery`; query: SerializedQueryIR; alias: string }
+  | { type: `union`; sources: Array<SerializedFrom>; alias: string }
+  | { type: `unionAll`; queries: Array<SerializedQueryIR>; alias: string }
 
 export type SerializedWhere =
   | SerializedExpression
@@ -113,18 +115,34 @@ export function serializeQueryIR(query: IR.QueryIR): SerializedQueryIR {
   return result
 }
 
-function serializeFrom(from: IR.CollectionRef | IR.QueryRef): SerializedFrom {
-  if (from.type === `collectionRef`) {
-    return {
-      type: `table`,
-      name: from.collection.id,
-      alias: from.alias,
-    }
-  }
-  return {
-    type: `subquery`,
-    query: serializeQueryIR(from.query),
-    alias: from.alias,
+function serializeFrom(from: IR.From): SerializedFrom {
+  switch (from.type) {
+    case `collectionRef`:
+      return {
+        type: `table`,
+        name: from.collection.id,
+        alias: from.alias,
+      }
+    case `queryRef`:
+      return {
+        type: `subquery`,
+        query: serializeQueryIR(from.query),
+        alias: from.alias,
+      }
+    case `unionFrom`:
+      return {
+        type: `union`,
+        sources: from.sources.map(serializeFrom),
+        alias: from.alias,
+      }
+    case `unionAll`:
+      return {
+        type: `unionAll`,
+        queries: from.queries.map(serializeQueryIR),
+        alias: from.alias,
+      }
+    default:
+      throw new Error(`Unknown from type: ${(from as { type: string }).type}`)
   }
 }
 

--- a/tests/serialize.test.ts
+++ b/tests/serialize.test.ts
@@ -1,0 +1,47 @@
+import { type BaseQueryBuilder, Query } from "@tanstack/db"
+import { describe, expect, test } from "vitest"
+import { serializeQueryIR } from "../src/serialize"
+import {
+  createMockedTodosCollection,
+  createMockedUsersCollection,
+  createMockFetch,
+} from "./test.utils"
+
+describe("serializeQueryIR FROM variants", () => {
+  const mockFetch = createMockFetch()
+  const usersCollection = createMockedUsersCollection(mockFetch)
+  const todosCollection = createMockedTodosCollection(mockFetch)
+
+  test("serializes a plain collection FROM as a table", () => {
+    const ir = (
+      new Query().from({
+        user: usersCollection,
+      }) as unknown as BaseQueryBuilder
+    )._getQuery()
+
+    const serialized = serializeQueryIR(ir)
+    expect(serialized.from).toMatchObject({ type: "table", name: "users" })
+  })
+
+  // Regression: @tanstack/db 0.6.x widened IR.From to include UnionFrom /
+  // UnionAll. Serialization used to only accept CollectionRef | QueryRef, so
+  // the package no longer type-checked and a union FROM was unrepresentable.
+  test("serializes a unionAll FROM without throwing", () => {
+    const ir = (
+      new Query().unionAll(
+        new Query().from({ user: usersCollection }),
+        new Query().from({ todo: todosCollection })
+      ) as unknown as BaseQueryBuilder
+    )._getQuery()
+
+    const serialized = serializeQueryIR(ir)
+    expect(serialized.from.type).toBe("unionAll")
+    if (serialized.from.type === "unionAll") {
+      expect(serialized.from.queries).toHaveLength(2)
+      expect(serialized.from.queries[0].from).toMatchObject({
+        type: "table",
+        name: "users",
+      })
+    }
+  })
+})


### PR DESCRIPTION
## Problem

`@tanstack/db` 0.6.x widened `IR.From` from `CollectionRef | QueryRef` to also include `UnionFrom` and `UnionAll`. `serializeFrom()` in `src/serialize.ts` only accepted the former two, so:

- The package no longer type-checks against its own `^0.6.0` dependency — `pnpm typecheck` fails:
  ```
  src/serialize.ts(70,25): error TS2345: Argument of type 'From' is not assignable to
    parameter of type 'CollectionRef | QueryRef'.
    Property 'query' is missing in type 'UnionFrom' but required in type 'QueryRef'.
  ```
- Union `FROM` clauses could not be represented at all.

`pnpm build` still passed (rolldown doesn't type-check), which is why this slipped through, but CI `typecheck` is red.

## Changes

- `serializeFrom` now accepts `IR.From` and serializes `unionFrom` / `unionAll` sources into two new `SerializedFrom` variants (`union`, `unionAll`).
- `queryOnce`'s `resolveFrom` narrows to `table` / `subquery` and throws a clear error for unions — a union has no single base table to push to a one-shot PostgREST request, so this fails loudly instead of silently producing a wrong query.
- Added `tests/serialize.test.ts` covering a plain collection `FROM` and a `unionAll` `FROM`.

## Verification

- `pnpm typecheck` — passes (was failing on `main`)
- `pnpm test` — 123 passing (was 121; +2 new)
- `pnpm build` — passes
- `pnpm check` — no new warnings introduced