### PR TITLE
add nested AND/OR and LIKE/ILIKE

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ Most query operations are translated to PostgREST filters and run server-side. A
 | Operation                                            | Notes                                                                             |
 | ---------------------------------------------------- | --------------------------------------------------------------------------------- |
 | `FROM`                                               | Maps to the PostgREST table endpoint.                                             |
-| `WHERE` (`eq`, `gt`, `gte`, `lt`, `lte`, `inArray`, `not`, `isNull`) | Translated to PostgREST filter syntax.                          |
-| `AND` (multiple conditions or chained `.where`)      | Translated to PostgREST filter syntax.                                            |
+| `WHERE` (`eq`, `gt`, `gte`, `lt`, `lte`, `inArray`, `like`, `ilike`, `not`, `isNull`) | Translated to PostgREST filter syntax.          |
+| `AND` (multiple conditions or chained `.where`)      | Translated to PostgREST filter syntax. A conjunct that cannot be pushed is dropped on its own; the request returns a superset and the client re-filters it. |
+| `OR` and nested `AND`/`OR`                           | Translated to PostgREST's `or=(…)` syntax. All-or-nothing: if any branch cannot be pushed the whole `or` is dropped, because dropping one branch would narrow the result and lose matching rows. |
 | `ORDER BY` (on source columns)                       | Translated to PostgREST filter syntax.                                            |
 | `LIMIT`                                              | Translated to PostgREST filter syntax.                                            |
 | `JOIN`                                               | Each table is fetched separately. The join key is pushed as an `in` filter on the second query. |
@@ -215,4 +216,3 @@ This library targets Supabase and PostgREST tables. For custom backends, write y
 ## Roadmap
 
 - Generate collection definitions from your database schema via the Supabase CLI, keeping them in sync as your schema evolves.
-- Add `OR` conditions and nested `AND`/`OR` support.

--- a/README.md
+++ b/README.md
@@ -183,6 +183,10 @@ Most query operations are translated to PostgREST filters and run server-side. A
 | `LIMIT`                                              | Translated to PostgREST filter syntax.                                            |
 | `JOIN`                                               | Each table is fetched separately. The join key is pushed as an `in` filter on the second query. |
 
+`like` and `ilike` use TanStack's SQL wildcards: `%` matches any sequence and `_` matches one character (for example, `ilike(user.name, "%alice%")`). Patterns containing a literal `*` are evaluated client-side because PostgREST interprets `*` as a wildcard. Filter values containing commas, parentheses, quotes, or backslashes are escaped automatically.
+
+The client-side filter fallback above applies to live queries and ordinary `queryOnce` queries. The server aggregate path in `queryOnce` requires fully pushable `WHERE` expressions and throws for unsupported filters, rather than returning an aggregate over unfiltered rows.
+
 **Evaluated Client-Side**
 
 These operations fetch the required rows and process them in memory:

--- a/src/functions.ts
+++ b/src/functions.ts
@@ -5,112 +5,59 @@ import {
   extractSimpleComparisons,
   type InsertMutationFnParams,
   type LoadSubsetOptions,
-  parseLoadSubsetOptions,
   parseOrderByExpression,
-  parseWhereExpression,
   type SimpleComparison,
   type UpdateMutationFnParams,
 } from "@tanstack/db"
 import type { QueryClient, QueryMeta } from "@tanstack/query-core"
+import {
+  applyPostgrestParams,
+  paramsToKey,
+  toPostgrestParams,
+} from "./postgrest-filters"
 import { CLIENT_INFO, CLIENT_INFO_HEADER } from "./request-headers"
 
-const mergeInFilters = (filters: SimpleComparison[]) => {
-  const mergedFilters: SimpleComparison[] = []
-  const filtersByField = new Map<string, SimpleComparison>()
+type GenericPostgrestFilterBuilder = PostgrestFilterBuilder<any, any, any, any>
 
-  for (const filter of filters) {
-    const field = filter.field?.join(".")
-    if (filter.operator !== "in" || !field) {
-      mergedFilters.push(filter)
-      continue
-    }
-
-    const values = Array.isArray(filter.value) ? filter.value : [filter.value]
-    const existingFilter = filtersByField.get(field)
-    if (existingFilter) {
-      existingFilter.value = Array.from(
-        new Set([...(existingFilter.value as unknown[]), ...values])
-      )
-      continue
-    }
-
-    const mergedFilter = {
-      ...filter,
-      value: Array.from(new Set(values)),
-    }
-    mergedFilters.push(mergedFilter)
-    filtersByField.set(field, mergedFilter)
-  }
-
-  return mergedFilters
-}
-
+/** Cursor filters arrive pre-flattened as `SimpleComparison`, not as IR. */
 const buildQuery = (
-  baseQuery: PostgrestFilterBuilder<any, any, any, any>,
+  baseQuery: GenericPostgrestFilterBuilder,
   filter: SimpleComparison
-) => {
+): GenericPostgrestFilterBuilder => {
+  const field = filter.field.join(".")
   if (filter.operator === "eq") {
-    baseQuery = baseQuery.eq(filter.field?.join("."), filter.value)
-  } else if (filter.operator === "gt") {
-    baseQuery = baseQuery.gt(filter.field?.join("."), filter.value)
-  } else if (filter.operator === "gte") {
-    baseQuery = baseQuery.gte(filter.field?.join("."), filter.value)
-  } else if (filter.operator === "lt") {
-    baseQuery = baseQuery.lt(filter.field?.join("."), filter.value)
-  } else if (filter.operator === "lte") {
-    baseQuery = baseQuery.lte(filter.field?.join("."), filter.value)
-  } else if (filter.operator === "in") {
-    baseQuery = baseQuery.in(filter.field?.join("."), filter.value)
-  } else if (filter.operator === "isNull") {
-    baseQuery = baseQuery.is(filter.field?.join("."), null)
-  } else if (filter.operator === "not_eq") {
-    baseQuery = baseQuery.not(filter.field?.join("."), "eq", filter.value)
-  } else {
-    console.warn(`buildQuery: unsupported operator: ${filter.operator}`)
+    return baseQuery.eq(field, filter.value)
   }
+  if (filter.operator === "gt") {
+    return baseQuery.gt(field, filter.value)
+  }
+  if (filter.operator === "gte") {
+    return baseQuery.gte(field, filter.value)
+  }
+  if (filter.operator === "lt") {
+    return baseQuery.lt(field, filter.value)
+  }
+  if (filter.operator === "lte") {
+    return baseQuery.lte(field, filter.value)
+  }
+  if (filter.operator === "in") {
+    return baseQuery.in(field, filter.value)
+  }
+  if (filter.operator === "isNull") {
+    return baseQuery.is(field, null)
+  }
+  if (filter.operator === "not_eq") {
+    return baseQuery.not(field, "eq", filter.value)
+  }
+  console.warn(`buildQuery: unsupported operator: ${filter.operator}`)
+  return baseQuery
 }
 
 export const subsetOptionsToQueryKey = (
   tableName: string,
   ctx: LoadSubsetOptions
 ) => {
-  const filters = parseWhereExpression(ctx.where, {
-    handlers: {
-      eq: (field, value) => {
-        return `${field.join(".")}=eq.${value}`
-      },
-      or: (field, value) => {
-        return `or(${field},${value})`
-      },
-      isNull: (field) => `${field.join(".")}=is.null`,
-      in: (field, value) => {
-        const uniqueValues = Array.from(new Set(value))
-        return `${field.join(".")}=in.${uniqueValues}`
-      },
-      and: (...filters) => {
-        return `${filters.map((filter) => filter).join("&")}`
-      },
-      gt: (field, value) => {
-        return `${field.join(".")}=gt.${value}`
-      },
-      gte: (field, value) => {
-        return `${field.join(".")}=gte.${value}`
-      },
-      lt: (field, value) => {
-        return `${field.join(".")}=lt.${value}`
-      },
-      lte: (field, value) => {
-        return `${field.join(".")}=lte.${value}`
-      },
-      not: (field, operator, value) => {
-        return field
-      },
-    },
-    onUnknownOperator: (operator, args) => {
-      console.warn(`Unsupported operator: ${operator}`)
-      return null
-    },
-  })
+  const filters = paramsToKey(toPostgrestParams(ctx.where, { mergeIn: true }))
 
   const sorts = parseOrderByExpression(ctx.orderBy)
   const limit = ctx.limit
@@ -150,39 +97,36 @@ export const supabaseQueryFn = async (
   const { limit, orderBy, offset, where, cursor } =
     ctx.meta?.loadSubsetOptions || {}
 
-  let cursorFilters: SimpleComparison[] = []
+  let cursorFilters: Array<SimpleComparison> = []
   if (cursor) {
     cursorFilters = [...extractSimpleComparisons(cursor.whereFrom)]
   }
-  // Parse the expressions into simple format
-  const parsed = parseLoadSubsetOptions({ orderBy, limit, where })
-  // console.log(tableName, parsed);
-  // console.log(tableName, cursorFilters);
+  const sorts = parseOrderByExpression(orderBy)
 
-  let baseQuery = supabase
+  let baseQuery: GenericPostgrestFilterBuilder = supabase
     .from(tableName)
     .select("*")
     .setHeader(CLIENT_INFO_HEADER, CLIENT_INFO)
 
-  if (parsed.limit) {
-    baseQuery = baseQuery.limit(parsed.limit)
+  if (limit) {
+    baseQuery = baseQuery.limit(limit)
   }
 
   if (offset) {
     baseQuery = baseQuery.range(offset, offset + 5)
   }
-  if (parsed.sorts) {
-    parsed.sorts.forEach((sort) => {
-      baseQuery = baseQuery.order(sort.field.join("."), {
-        ascending: sort.direction === "asc",
-      })
+  for (const sort of sorts) {
+    baseQuery = baseQuery.order(sort.field.join("."), {
+      ascending: sort.direction === "asc",
     })
   }
 
-  if (parsed.filters) {
-    mergeInFilters([...parsed.filters, ...cursorFilters]).forEach((filter) => {
-      buildQuery(baseQuery, filter)
-    })
+  baseQuery = applyPostgrestParams(
+    baseQuery,
+    toPostgrestParams(where, { mergeIn: true })
+  )
+  for (const filter of cursorFilters) {
+    baseQuery = buildQuery(baseQuery, filter)
   }
 
   const { data, error } = await baseQuery

--- a/src/postgrest-filters.ts
+++ b/src/postgrest-filters.ts
@@ -34,13 +34,18 @@ function renderComparison(
   if (expr.type !== "func") return null
   const [left, right] = expr.args
   if (expr.name === "not" && left) {
+    if (left.type === "func" && left.name === "not" && left.args[0]) {
+      return renderComparison(left.args[0], quoteScalars, options)
+    }
     const inner = renderComparison(left, quoteScalars, options)
     if (!inner) return null
+    // TanStack's NOT IN [] excludes nulls; PostgREST's NOT IN () includes them.
+    if (inner.operator === "in" && inner.value === "()") {
+      return { ...inner, operator: "not.is", value: "null" }
+    }
     return {
       ...inner,
-      operator: inner.operator.startsWith("not.")
-        ? inner.operator.slice(4)
-        : `not.${inner.operator}`,
+      operator: `not.${inner.operator}`,
     }
   }
   if (left?.type !== "ref" || left.path[0] === "$selected") return null
@@ -51,10 +56,18 @@ function renderComparison(
 
   if (expr.name === "in") {
     if (!Array.isArray(right.value)) return null
+    // TanStack's membership test ignores null list members for non-null rows.
+    const values = Array.from(
+      new Set(right.value.filter((value) => value != null))
+    )
+    // PostgREST treats IN ("") as an empty list, even when quoted.
+    if (values.length === 1 && values[0] === "") {
+      return { column, operator: "eq", value: quoteScalars ? '""' : "" }
+    }
     return {
       column,
       operator: "in",
-      value: `(${Array.from(new Set(right.value)).map(quoteValue).join(",")})`,
+      value: `(${values.map(quoteValue).join(",")})`,
     }
   }
   if (!SCALAR_OPERATORS.includes(expr.name)) return null
@@ -76,27 +89,26 @@ function renderComparison(
 // could narrow the response and permanently lose matching rows.
 function toFilterString(
   expr: Expression,
-  options: FilterOptions
+  options: FilterOptions,
+  negated = false
 ): string | null {
   if (expr.type !== "func") return null
+  if (expr.name === "not") {
+    return expr.args[0] ? toFilterString(expr.args[0], options, !negated) : null
+  }
   if (expr.name === "and" || expr.name === "or") {
     if (expr.args.length === 0) return null
-    const parts = expr.args.map((arg) => toFilterString(arg, options))
-    return parts.includes(null) ? null : `${expr.name}(${parts.join(",")})`
+    // Move NOT down to comparisons with De Morgan's laws. In particular, an
+    // empty IN list needs its null guard even under a negated logical group.
+    const operator = negated ? (expr.name === "and" ? "or" : "and") : expr.name
+    const parts = expr.args.map((arg) => toFilterString(arg, options, negated))
+    return parts.includes(null) ? null : `${operator}(${parts.join(",")})`
   }
-  if (expr.name === "not") {
-    const [inner] = expr.args
-    if (inner?.type === "func") {
-      if (inner.name === "not" && inner.args[0]) {
-        return toFilterString(inner.args[0], options)
-      }
-      if (inner.name === "and" || inner.name === "or") {
-        const filter = toFilterString(inner, options)
-        return filter === null ? null : `not.${filter}`
-      }
-    }
-  }
-  const comparison = renderComparison(expr, true, options)
+  const comparison = renderComparison(
+    negated ? { type: "func", name: "not", args: [expr] } : expr,
+    true,
+    options
+  )
   return comparison
     ? `${comparison.column}.${comparison.operator}.${comparison.value}`
     : null
@@ -156,10 +168,7 @@ export function toPostgrestParams(
       return [
         {
           kind: "group",
-          filter:
-            filter.type === "func" && filter.name === "or"
-              ? embedded.slice(3, -1)
-              : embedded,
+          filter: embedded.startsWith("or(") ? embedded.slice(3, -1) : embedded,
         },
       ]
     }

--- a/src/postgrest-filters.ts
+++ b/src/postgrest-filters.ts
@@ -1,0 +1,196 @@
+import type { PostgrestFilterBuilder } from "@supabase/postgrest-js"
+import type { SerializedExpression as Expression } from "./serialize"
+
+type SupabaseQuery = PostgrestFilterBuilder<any, any, any, any>
+
+type Comparison = { column: string; operator: string; value: string }
+export type PostgrestParam =
+  | ({ kind: "column" } & Comparison)
+  | { kind: "group"; filter: string }
+
+interface FilterOptions {
+  mergeIn?: boolean
+  strict?: boolean
+  stripAlias?: boolean
+}
+
+// Only lists and logical groups parse quoted values. Top-level scalar values
+// must remain raw: col=eq."x" would match the quotes themselves.
+const NEEDS_QUOTES = /^$|^\s|\s$|[,()"\\]/
+const quoteValue = (value: unknown): string => {
+  const raw = `${value}`
+  return NEEDS_QUOTES.test(raw)
+    ? `"${raw.replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"`
+    : raw
+}
+
+const SCALAR_OPERATORS = ["eq", "gt", "gte", "lt", "lte", "like", "ilike"]
+
+function renderComparison(
+  expr: Expression,
+  quoteScalars: boolean,
+  options: FilterOptions
+): Comparison | null {
+  if (expr.type !== "func") return null
+  const [left, right] = expr.args
+  if (expr.name === "not" && left) {
+    const inner = renderComparison(left, quoteScalars, options)
+    if (!inner) return null
+    return {
+      ...inner,
+      operator: inner.operator.startsWith("not.")
+        ? inner.operator.slice(4)
+        : `not.${inner.operator}`,
+    }
+  }
+  if (left?.type !== "ref" || left.path[0] === "$selected") return null
+  const column = (options.stripAlias ? left.path.slice(1) : left.path).join(".")
+  if (!column) return null
+  if (expr.name === "isNull") return { column, operator: "is", value: "null" }
+  if (right?.type !== "val") return null
+
+  if (expr.name === "in") {
+    if (!Array.isArray(right.value)) return null
+    return {
+      column,
+      operator: "in",
+      value: `(${Array.from(new Set(right.value)).map(quoteValue).join(",")})`,
+    }
+  }
+  if (!SCALAR_OPERATORS.includes(expr.name)) return null
+  let value = right.value
+  if (expr.name === "like" || expr.name === "ilike") {
+    // TanStack uses SQL %/_ wildcards, but treats * and backslashes literally.
+    // PostgREST always rewrites * to %, so such patterns cannot be pushed.
+    if (typeof value !== "string" || value.includes("*")) return null
+    value = value.replace(/\\/g, "\\\\")
+  }
+  return {
+    column,
+    operator: expr.name,
+    value: quoteScalars ? quoteValue(value) : `${value}`,
+  }
+}
+
+// Embedded expressions are all-or-nothing. Dropping a child of OR or NOT
+// could narrow the response and permanently lose matching rows.
+function toFilterString(
+  expr: Expression,
+  options: FilterOptions
+): string | null {
+  if (expr.type !== "func") return null
+  if (expr.name === "and" || expr.name === "or") {
+    if (expr.args.length === 0) return null
+    const parts = expr.args.map((arg) => toFilterString(arg, options))
+    return parts.includes(null) ? null : `${expr.name}(${parts.join(",")})`
+  }
+  if (expr.name === "not") {
+    const [inner] = expr.args
+    if (inner?.type === "func") {
+      if (inner.name === "not" && inner.args[0]) {
+        return toFilterString(inner.args[0], options)
+      }
+      if (inner.name === "and" || inner.name === "or") {
+        const filter = toFilterString(inner, options)
+        return filter === null ? null : `not.${filter}`
+      }
+    }
+  }
+  const comparison = renderComparison(expr, true, options)
+  return comparison
+    ? `${comparison.column}.${comparison.operator}.${comparison.value}`
+    : null
+}
+
+function flattenAnd(expr: Expression): Expression[] {
+  return expr.type === "func" && expr.name === "and"
+    ? expr.args.flatMap(flattenAnd)
+    : [expr]
+}
+
+// Preserve the live adapter's union of duplicate IN demands. This deliberately
+// fetches a superset, which TanStack re-filters. Never do this inside OR/NOT or
+// for server aggregates, where client-side filtering cannot repair the result.
+function mergeInFilters(filters: Expression[]): Expression[] {
+  const merged: Expression[] = []
+  const valuesByField = new Map<string, unknown[]>()
+  for (const filter of filters) {
+    if (filter.type !== "func" || filter.name !== "in") {
+      merged.push(filter)
+      continue
+    }
+    const [left, right] = filter.args
+    if (
+      left?.type !== "ref" ||
+      right?.type !== "val" ||
+      !Array.isArray(right.value)
+    ) {
+      merged.push(filter)
+      continue
+    }
+    const field = JSON.stringify(left.path)
+    const existing = valuesByField.get(field)
+    if (existing) {
+      existing.push(...right.value)
+    } else {
+      const values = [...right.value]
+      valuesByField.set(field, values)
+      merged.push({ ...filter, args: [left, { type: "val", value: values }] })
+    }
+  }
+  return merged
+}
+
+export function toPostgrestParams(
+  expr: Expression | undefined | null,
+  options: FilterOptions = {}
+): PostgrestParam[] {
+  if (!expr) return []
+  const conjuncts = flattenAnd(expr)
+  const filters = options.mergeIn ? mergeInFilters(conjuncts) : conjuncts
+  return filters.flatMap((filter): PostgrestParam[] => {
+    const comparison = renderComparison(filter, false, options)
+    if (comparison) return [{ kind: "column", ...comparison }]
+    const embedded = toFilterString(filter, options)
+    if (embedded !== null) {
+      return [
+        {
+          kind: "group",
+          filter:
+            filter.type === "func" && filter.name === "or"
+              ? embedded.slice(3, -1)
+              : embedded,
+        },
+      ]
+    }
+    if (options.strict) {
+      throw new Error(
+        "Cannot push WHERE expression to PostgREST; server aggregates require fully pushable filters"
+      )
+    }
+    return []
+  })
+}
+
+export function applyPostgrestParams(
+  query: SupabaseQuery,
+  params: PostgrestParam[]
+): SupabaseQuery {
+  for (const param of params) {
+    query =
+      param.kind === "column"
+        ? query.filter(param.column, param.operator, param.value)
+        : query.or(param.filter)
+  }
+  return query
+}
+
+export function paramsToKey(params: PostgrestParam[]): string {
+  const search = new URLSearchParams()
+  for (const param of params) {
+    if (param.kind === "column")
+      search.append(param.column, `${param.operator}.${param.value}`)
+    else search.append("or", `(${param.filter})`)
+  }
+  return search.toString()
+}

--- a/src/query-once.ts
+++ b/src/query-once.ts
@@ -9,6 +9,7 @@ import {
   type QueryBuilder,
   queryOnce as queryOnceBase,
 } from "@tanstack/db"
+import { applyPostgrestParams, toPostgrestParams } from "./postgrest-filters"
 import { CLIENT_INFO, CLIENT_INFO_HEADER } from "./request-headers"
 import {
   type SerializedExpression,
@@ -30,14 +31,6 @@ function refToColumn(expr: SerializedExpression): string {
     throw new Error(`Expected ref expression, got ${expr.type}`)
   }
   return expr.path.slice(1).join(".")
-}
-
-/** Extract literal value from a val expression */
-function extractValue(expr: SerializedExpression): unknown {
-  if (expr.type !== "val") {
-    throw new Error(`Expected val expression, got ${expr.type}`)
-  }
-  return expr.value
 }
 
 /** Unwrap a SerializedWhere to its expression */
@@ -312,186 +305,6 @@ function renderEmbedNode(node: EmbedNode): string {
   return `${node.tableName}${hintStr}${typeStr}(${innerParts.join(", ")})`
 }
 
-// ── Filter string conversion (for .or() and .not()) ────────────────
-
-/** Convert a comparison expression to a PostgREST filter string */
-function toFilterString(expr: SerializedExpression): string {
-  if (expr.type !== "func") {
-    throw new Error(`Expected func expression, got ${expr.type}`)
-  }
-
-  switch (expr.name) {
-    case "eq":
-      return `${refToColumn(expr.args[0])}.eq.${extractValue(expr.args[1])}`
-    case "neq":
-      return `${refToColumn(expr.args[0])}.neq.${extractValue(expr.args[1])}`
-    case "gt":
-      return `${refToColumn(expr.args[0])}.gt.${extractValue(expr.args[1])}`
-    case "gte":
-      return `${refToColumn(expr.args[0])}.gte.${extractValue(expr.args[1])}`
-    case "lt":
-      return `${refToColumn(expr.args[0])}.lt.${extractValue(expr.args[1])}`
-    case "lte":
-      return `${refToColumn(expr.args[0])}.lte.${extractValue(expr.args[1])}`
-    case "isNull":
-      return `${refToColumn(expr.args[0])}.is.null`
-    case "inArray": {
-      const values = extractValue(expr.args[1]) as unknown[]
-      return `${refToColumn(expr.args[0])}.in.(${values.join(",")})`
-    }
-    case "not":
-      return toNotFilterString(expr.args[0])
-    case "and":
-      return `and(${expr.args.map(toFilterString).join(",")})`
-    case "or":
-      return `or(${expr.args.map(toFilterString).join(",")})`
-    default:
-      throw new Error(`Unsupported operator in filter string: ${expr.name}`)
-  }
-}
-
-/** Convert the inner expression of a NOT to a negated PostgREST filter string */
-function toNotFilterString(expr: SerializedExpression): string {
-  if (expr.type !== "func") {
-    throw new Error(`Expected func inside not, got ${expr.type}`)
-  }
-  switch (expr.name) {
-    case "eq":
-      return `${refToColumn(expr.args[0])}.not.eq.${extractValue(expr.args[1])}`
-    case "neq":
-      return `${refToColumn(expr.args[0])}.not.neq.${extractValue(expr.args[1])}`
-    case "gt":
-      return `${refToColumn(expr.args[0])}.not.gt.${extractValue(expr.args[1])}`
-    case "gte":
-      return `${refToColumn(expr.args[0])}.not.gte.${extractValue(expr.args[1])}`
-    case "lt":
-      return `${refToColumn(expr.args[0])}.not.lt.${extractValue(expr.args[1])}`
-    case "lte":
-      return `${refToColumn(expr.args[0])}.not.lte.${extractValue(expr.args[1])}`
-    case "isNull":
-      return `${refToColumn(expr.args[0])}.not.is.null`
-    case "inArray": {
-      const values = extractValue(expr.args[1]) as unknown[]
-      return `${refToColumn(expr.args[0])}.not.in.(${values.join(",")})`
-    }
-    default:
-      return `${refToColumn(expr.args[0])}.not.${expr.name}.${extractValue(expr.args[1])}`
-  }
-}
-
-// ── Filter application ──────────────────────────────────────────────
-
-/** Apply a single where expression to a Supabase query builder */
-function applyFilter(
-  query: SupabaseQuery,
-  expr: SerializedExpression
-): SupabaseQuery {
-  if (expr.type !== "func") {
-    console.warn(`Cannot push non-func expression to PostgREST: ${expr.type}`)
-    return query
-  }
-
-  switch (expr.name) {
-    case "eq":
-      return query.eq(refToColumn(expr.args[0]), extractValue(expr.args[1]))
-    case "neq":
-      return query.neq(refToColumn(expr.args[0]), extractValue(expr.args[1]))
-    case "gt":
-      return query.gt(refToColumn(expr.args[0]), extractValue(expr.args[1]))
-    case "gte":
-      return query.gte(refToColumn(expr.args[0]), extractValue(expr.args[1]))
-    case "lt":
-      return query.lt(refToColumn(expr.args[0]), extractValue(expr.args[1]))
-    case "lte":
-      return query.lte(refToColumn(expr.args[0]), extractValue(expr.args[1]))
-    case "isNull":
-      return query.is(refToColumn(expr.args[0]), null)
-    case "inArray":
-      return query.in(
-        refToColumn(expr.args[0]),
-        extractValue(expr.args[1]) as unknown[]
-      )
-    case "not":
-      return applyNotFilter(query, expr.args[0])
-    case "and":
-      // AND is implicit in PostgREST — apply each filter sequentially
-      for (const arg of expr.args) {
-        query = applyFilter(query, arg)
-      }
-      return query
-    case "or":
-      return query.or(expr.args.map(toFilterString).join(","))
-    default:
-      console.warn(`Unsupported operator for PostgREST: ${expr.name}`)
-      return query
-  }
-}
-
-/** Apply a NOT(inner) filter to a Supabase query builder */
-function applyNotFilter(
-  query: SupabaseQuery,
-  inner: SerializedExpression
-): SupabaseQuery {
-  if (inner.type !== "func") {
-    console.warn(`Cannot push non-func inside not to PostgREST`)
-    return query
-  }
-  switch (inner.name) {
-    case "eq":
-      return query.not(
-        refToColumn(inner.args[0]),
-        "eq",
-        extractValue(inner.args[1]) as string
-      )
-    case "neq":
-      return query.not(
-        refToColumn(inner.args[0]),
-        "neq",
-        extractValue(inner.args[1]) as string
-      )
-    case "gt":
-      return query.not(
-        refToColumn(inner.args[0]),
-        "gt",
-        extractValue(inner.args[1]) as string
-      )
-    case "gte":
-      return query.not(
-        refToColumn(inner.args[0]),
-        "gte",
-        extractValue(inner.args[1]) as string
-      )
-    case "lt":
-      return query.not(
-        refToColumn(inner.args[0]),
-        "lt",
-        extractValue(inner.args[1]) as string
-      )
-    case "lte":
-      return query.not(
-        refToColumn(inner.args[0]),
-        "lte",
-        extractValue(inner.args[1]) as string
-      )
-    case "isNull":
-      return query.not(refToColumn(inner.args[0]), "is", null as any)
-    case "inArray": {
-      const values = extractValue(inner.args[1]) as unknown[]
-      return query.not(
-        refToColumn(inner.args[0]),
-        "in",
-        `(${values.join(",")})` as any
-      )
-    }
-    default:
-      return query.not(
-        refToColumn(inner.args[0]),
-        inner.name as any,
-        extractValue(inner.args[1]) as any
-      )
-  }
-}
-
 // ── Query building ──────────────────────────────────────────────────
 
 /**
@@ -500,7 +313,7 @@ function applyNotFilter(
  * Pushes to PostgREST:
  * - **select**: column refs, aggregates (count/sum/avg/min/max)
  * - **joins**: resource embedding with `!inner` / `!left` hints
- * - **where**: eq, neq, gt, gte, lt, lte, isNull, inArray, not, and, or
+ * - **where**: eq, gt, gte, lt, lte, like, ilike, isNull, in, not, and, or
  * - **orderBy**: real column refs (skips computed/$selected)
  * - **limit / offset**
  *
@@ -524,7 +337,10 @@ export function buildSupabaseQuery(
   // Apply pushable where filters (skip residual / client-side filters)
   for (const w of allWheres) {
     if (isResidual(w)) continue
-    query = applyFilter(query, getExpression(w))
+    query = applyPostgrestParams(
+      query,
+      toPostgrestParams(getExpression(w), { stripAlias: true, strict: true })
+    )
   }
 
   // Apply order by (only real column refs, skip computed/$selected refs)

--- a/tests/e2e/filters.test.ts
+++ b/tests/e2e/filters.test.ts
@@ -1,0 +1,133 @@
+import { and, eq, IR, ilike, inArray, like, not, or, upper } from "@tanstack/db"
+import { expect } from "vitest"
+import { queryOnce } from "../../src/index"
+import { executeQuery } from "../../src/query-once"
+import { test } from "./e2e.utils"
+
+const name = new IR.PropRef<string>(["user", "name"])
+const active = new IR.PropRef<boolean>(["user", "active"])
+const id = new IR.PropRef<number>(["user", "id"])
+
+const cases = [
+  ["OR", or(eq(name, "Alice"), eq(name, "Nobody")), ["Alice"]],
+  [
+    "nested AND/OR",
+    or(and(eq(active, true), eq(name, "Bob")), eq(id, 2)),
+    ["Bob"],
+  ],
+  ["NOT AND", not(and(eq(active, true), eq(name, "Alice"))), ["Bob"]],
+  ["NOT OR", not(or(eq(active, true), eq(name, "Nobody"))), ["Bob"]],
+  ["double NOT", not(not(or(eq(active, true), eq(name, "Nobody")))), ["Alice"]],
+  ["LIKE", like(name, "A_i%"), ["Alice"]],
+  ["ILIKE", ilike(name, "%ALI%"), ["Alice"]],
+  ["NOT LIKE", not(like(name, "A%")), ["Bob"]],
+  [
+    "OR ILIKE",
+    or(ilike(name, "%ali%"), ilike(name, "%bOB%")),
+    ["Alice", "Bob"],
+  ],
+  ["overlapping IN", and(inArray(id, [1, 2]), inArray(id, [2, 3])), ["Bob"]],
+  ["empty IN", inArray(id, []), []],
+  ["NOT empty IN", not(inArray(id, [])), ["Alice", "Bob"]],
+  ["NOT IN with null", not(inArray(name, ["Alice", null])), ["Bob"]],
+] as const
+
+// Both routes assert real returned rows, not merely the shape of a URL.
+// executeQuery exercises the serializer used for server-side aggregates.
+for (const [label, where, expected] of cases) {
+  test(`${label} returns matching rows on both query paths`, async ({
+    users,
+  }) => {
+    const liveRows = await queryOnce(
+      (q) => q.from({ user: users.collection }).where(() => where),
+      users.supabase
+    )
+    const serverRows = (await executeQuery(users.supabase, {
+      from: { type: "table", name: "users", alias: "user" },
+      where: [where],
+    })) as { name: string }[]
+    expect(liveRows.map((row) => row.name).sort()).toEqual(expected)
+    expect(serverRows.map((row) => row.name).sort()).toEqual(expected)
+  })
+}
+
+for (const value of ["", " a ", "a,b(c)", 'a"b\\c', "a.b:c&d=1+%", "{a,b}"]) {
+  test(`reserved value ${JSON.stringify(value)} round-trips through filters`, async ({
+    users,
+  }) => {
+    const { error } = await users.supabase
+      .from("users")
+      .insert({ name: value, email: "special@test.com" })
+    expect(error).toBeNull()
+    for (const where of [
+      eq(name, value),
+      or(eq(name, value), eq(id, -1)),
+      inArray(name, [value]),
+    ]) {
+      const liveRows = await queryOnce(
+        (q) => q.from({ user: users.collection }).where(() => where),
+        users.supabase
+      )
+      const serverRows = (await executeQuery(users.supabase, {
+        from: { type: "table", name: "users", alias: "user" },
+        where: [where],
+      })) as { name: string }[]
+      expect(
+        liveRows.map((row) => row.name),
+        JSON.stringify(where)
+      ).toEqual([value])
+      expect(serverRows.map((row) => row.name)).toEqual([value])
+    }
+  })
+}
+
+test("LIKE treats backslashes literally on both paths", async ({ users }) => {
+  const value = "a\\path"
+  const { error } = await users.supabase
+    .from("users")
+    .insert({ name: value, email: "slash@test.com" })
+  expect(error).toBeNull()
+  for (const where of [
+    like(name, "a\\%"),
+    or(like(name, "a\\%"), eq(id, -1)),
+  ]) {
+    const liveRows = await queryOnce(
+      (q) => q.from({ user: users.collection }).where(() => where),
+      users.supabase
+    )
+    const serverRows = (await executeQuery(users.supabase, {
+      from: { type: "table", name: "users", alias: "user" },
+      where: [where],
+    })) as { name: string }[]
+    expect(
+      liveRows.map((row) => row.name),
+      JSON.stringify(where)
+    ).toEqual([value])
+    expect(serverRows.map((row) => row.name)).toEqual([value])
+  }
+})
+
+test("unsupported OR and negated patterns retain rows for client filtering", async ({
+  users,
+}) => {
+  const computedRows = await queryOnce(
+    (q) =>
+      q
+        .from({ user: users.collection })
+        .where(({ user }) =>
+          or(eq(user.name, "Nobody"), eq(upper(user.name), "ALICE"))
+        ),
+    users.supabase
+  )
+  expect(computedRows.map((row) => row.name)).toEqual(["Alice"])
+  // PostgREST would interpret * as a wildcard and remove Alice here, whereas
+  // TanStack treats it literally and should keep both seeded names.
+  const literalRows = await queryOnce(
+    (q) =>
+      q
+        .from({ user: users.collection })
+        .where(({ user }) => not(like(user.name, "*Ali*"))),
+    users.supabase
+  )
+  expect(literalRows.map((row) => row.name).sort()).toEqual(["Alice", "Bob"])
+})

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -8,10 +8,12 @@ import {
   eq,
   gt,
   gte,
+  ilike,
   inArray,
   isNull,
   isUndefined,
   length,
+  like,
   lower,
   lt,
   lte,
@@ -186,18 +188,53 @@ describe("PostgREST query generation", () => {
       ])
     })
 
-    test.todo("OR: active = true OR id = 1", async () => {
+    test("WHERE name LIKE '%Ali%'", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) => like(user.name, "%Ali%"))
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=*&name=like.%25Ali%25",
+      ])
+    })
+
+    test("WHERE name ILIKE '%ali%'", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) => ilike(user.name, "%ali%"))
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=*&name=ilike.%25ali%25",
+      ])
+    })
+
+    test("OR: active = true OR id = 1", async () => {
       await queryResult((q) =>
         q
           .from({ user: usersCollection })
           .where(({ user }) => or(eq(user.active, true), eq(user.id, 1)))
       )
       expectFetchUrls(mockFetch, [
-        "/rest/v1/users?select=*&active=eq.true&id=eq.1",
+        "/rest/v1/users?select=*&or=(active.eq.true,id.eq.1)",
       ])
     })
 
-    test.todo("nested AND/OR: active = true AND (id > 5 OR name = 'admin')", async () => {
+    test("OR of ILIKEs (search across columns)", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) =>
+            or(ilike(user.name, "%ali%"), ilike(user.email, "%ali%"))
+          )
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=*&or=(name.ilike.%25ali%25,email.ilike.%25ali%25)",
+      ])
+    })
+
+    test("nested AND/OR: active = true AND (id > 5 OR name = 'admin')", async () => {
       await queryResult((q) =>
         q
           .from({ user: usersCollection })
@@ -208,6 +245,71 @@ describe("PostgREST query generation", () => {
             )
           )
       )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=*&active=eq.true&or=(id.gt.5,name.eq.admin)",
+      ])
+    })
+
+    test("nested AND/OR of ILIKEs", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) =>
+            and(
+              eq(user.active, true),
+              or(ilike(user.name, "%ali%"), ilike(user.email, "%ali%"))
+            )
+          )
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=*&active=eq.true&or=(name.ilike.%25ali%25,email.ilike.%25ali%25)",
+      ])
+    })
+
+    test("value containing a comma is quoted", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) =>
+            or(ilike(user.name, "%a,b%"), eq(user.email, "x,y"))
+          )
+      )
+      expectFetchUrls(mockFetch, [
+        '/rest/v1/users?select=*&or=(name.ilike."%25a,b%25",email.eq."x,y")',
+      ])
+    })
+
+    test("IN list quotes members containing reserved characters", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) => inArray(user.name, ["plain", "a,b", "c(d)"]))
+      )
+      expectFetchUrls(mockFetch, [
+        '/rest/v1/users?select=*&name=in.(plain,"a,b","c(d)")',
+      ])
+    })
+
+    test("AND drops only the unpushable conjunct", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) =>
+            and(eq(user.active, true), eq(upper(user.name), "ALICE"))
+          )
+      )
+      expectFetchUrls(mockFetch, ["/rest/v1/users?select=*&active=eq.true"])
+    })
+
+    test("OR containing an unpushable branch is dropped entirely", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) =>
+            or(eq(user.active, true), eq(upper(user.name), "ALICE"))
+          )
+      )
+      expectFetchUrls(mockFetch, ["/rest/v1/users?select=*"])
     })
   })
 

--- a/tests/postgrest-filters.test.ts
+++ b/tests/postgrest-filters.test.ts
@@ -1,0 +1,224 @@
+import { createClient } from "@supabase/supabase-js"
+import {
+  and,
+  eq,
+  gt,
+  IR,
+  ilike,
+  inArray,
+  isNull,
+  like,
+  not,
+  or,
+  upper,
+} from "@tanstack/db"
+import { QueryClient } from "@tanstack/query-core"
+import { describe, expect, test } from "vitest"
+import { subsetOptionsToQueryKey, supabaseQueryFn } from "../src/functions"
+import { buildSupabaseQuery } from "../src/query-once"
+import { createMockFetch, SUPABASE_KEY, SUPABASE_URL } from "./test.utils"
+
+// Exercise the real request builders on both paths. queryOnce without an
+// aggregate delegates to TanStack and would only test the live path again.
+describe.each([
+  "live",
+  "server",
+] as const)("%s filter serialization", (path) => {
+  const ref = (column: string) =>
+    new IR.PropRef(path === "server" ? ["user", column] : [column])
+  const name = ref("name")
+  const id = ref("id")
+  const active = ref("active")
+
+  async function request(where: IR.BasicExpression<boolean>) {
+    const mockFetch = createMockFetch()
+    const supabase = createClient(SUPABASE_URL, SUPABASE_KEY, {
+      global: { fetch: mockFetch },
+    })
+    if (path === "server") {
+      await buildSupabaseQuery(supabase, {
+        from: { type: "table", name: "users", alias: "user" },
+        where: [where],
+      })
+    } else {
+      await supabaseQueryFn(supabase, "users", {
+        client: new QueryClient(),
+        queryKey: ["users"],
+        signal: new AbortController().signal,
+        meta: { loadSubsetOptions: { where } },
+      })
+    }
+    return new URL(String(mockFetch.mock.calls[0][0])).searchParams
+  }
+
+  test("preserves AND branches inside OR", async () => {
+    const params = await request(
+      or(and(eq(active, true), gt(id, 1)), eq(name, "Bob"))
+    )
+    expect(params.get("or")).toBe("(and(active.eq.true,id.gt.1),name.eq.Bob)")
+  })
+
+  test.each([and, or])("negates logical groups", async (logical) => {
+    const params = await request(
+      not(logical(eq(active, true), eq(name, "Bob")))
+    )
+    expect(params.get("or")).toBe(
+      logical === and
+        ? "(active.not.eq.true,name.not.eq.Bob)"
+        : "(and(active.not.eq.true,name.not.eq.Bob))"
+    )
+  })
+
+  test("supports double negation of comparisons and logical groups", async () => {
+    expect((await request(not(not(eq(name, "Alice"))))).get("name")).toBe(
+      "eq.Alice"
+    )
+    expect(
+      (await request(not(not(or(eq(name, "Alice"), eq(id, 2)))))).get("or")
+    ).toBe("(name.eq.Alice,id.eq.2)")
+  })
+
+  test("preserves multiple OR parameters under AND", async () => {
+    const params = await request(
+      and(or(eq(id, 1), eq(id, 2)), or(eq(name, "Alice"), eq(name, "Bob")))
+    )
+    expect(params.getAll("or")).toEqual([
+      "(id.eq.1,id.eq.2)",
+      "(name.eq.Alice,name.eq.Bob)",
+    ])
+  })
+
+  test.each([
+    ["", '""'],
+    [" a ", '" a "'],
+    ["a,b(c)", '"a,b(c)"'],
+    ['a"b\\c', '"a\\"b\\\\c"'],
+    ["a.b:c&d=1+%", "a.b:c&d=1+%"],
+  ])("quotes logical values and IN members: %j", async (value, quoted) => {
+    expect((await request(or(eq(name, value), eq(id, 2)))).get("or")).toBe(
+      `(name.eq.${quoted},id.eq.2)`
+    )
+    expect((await request(inArray(name, [value, value]))).get("name")).toBe(
+      value === "" ? "eq." : `in.(${quoted})`
+    )
+    expect((await request(not(inArray(name, [value])))).get("name")).toBe(
+      value === "" ? "not.eq." : `not.in.(${quoted})`
+    )
+    expect((await request(eq(name, value))).get("name")).toBe(`eq.${value}`)
+    expect((await request(not(eq(name, value)))).get("name")).toBe(
+      `not.eq.${value}`
+    )
+  })
+
+  test("renders negated comparisons inside OR", async () => {
+    const params = await request(
+      or(not(isNull(name)), not(inArray(name, ["a,b", "c"])))
+    )
+    expect(params.get("or")).toBe('(name.not.is.null,name.not.in.("a,b",c))')
+  })
+
+  test("does not union IN constraints inside logical groups", async () => {
+    const params = await request(
+      or(and(inArray(id, [1, 2]), inArray(id, [2, 3])), eq(active, true))
+    )
+    expect(params.get("or")).toBe(
+      "(and(id.in.(1,2),id.in.(2,3)),active.eq.true)"
+    )
+  })
+
+  test("merges top-level IN demands only for live queries without mutating IR", async () => {
+    const where = and(
+      inArray(id, [1, 2]),
+      and(inArray(id, [2, 3]), eq(active, true))
+    )
+    const before = JSON.stringify(where)
+    expect((await request(where)).getAll("id")).toEqual(
+      path === "live" ? ["in.(1,2,3)"] : ["in.(1,2)", "in.(2,3)"]
+    )
+    expect(JSON.stringify(where)).toBe(before)
+  })
+
+  test("renders empty IN lists with SQL null semantics", async () => {
+    expect((await request(inArray(id, []))).get("id")).toBe("in.()")
+    expect((await request(not(inArray(id, [])))).get("id")).toBe("not.is.null")
+    expect((await request(not(not(inArray(id, []))))).get("id")).toBe("in.()")
+  })
+
+  test("preserves null guards for empty IN inside a negated logical group", async () => {
+    const params = await request(not(and(inArray(name, []), eq(active, true))))
+    expect(params.get("or")).toBe("(name.not.is.null,active.not.eq.true)")
+  })
+
+  test("ignores null list members instead of matching literal null strings", async () => {
+    expect((await request(inArray(name, ["Alice", null]))).get("name")).toBe(
+      "in.(Alice)"
+    )
+    expect(
+      (await request(not(inArray(name, ["Alice", null])))).get("name")
+    ).toBe("not.in.(Alice)")
+    expect((await request(not(inArray(name, [null])))).get("name")).toBe(
+      "not.is.null"
+    )
+  })
+
+  test.each([
+    like,
+    ilike,
+  ])("preserves SQL wildcards and literal backslashes", async (match) => {
+    expect((await request(match(name, "A_%"))).get("name")).toBe(
+      `${match === like ? "like" : "ilike"}.A_%`
+    )
+    expect((await request(not(match(name, "a\\%")))).get("name")).toBe(
+      `not.${match === like ? "like" : "ilike"}.a\\\\%`
+    )
+  })
+
+  test.each([
+    ["computed OR", or(eq(active, true), eq(upper(name), "ALICE"))],
+    ["computed NOT AND", not(and(eq(active, true), eq(upper(name), "ALICE")))],
+    ["literal asterisk", like(name, "*Ali*")],
+    ["negated literal asterisk", not(ilike(name, "*Ali*"))],
+  ])("handles unsupported %s without narrowing results", async (_, where) => {
+    if (path === "server") {
+      await expect(request(where)).rejects.toThrow("fully pushable filters")
+    } else {
+      const params = await request(and(gt(id, 0), where))
+      expect([...params]).toEqual([
+        ["select", "*"],
+        ["id", "gt.0"],
+      ])
+    }
+  })
+})
+
+describe("filter cache keys", () => {
+  const name = new IR.PropRef<string>(["name"])
+  const active = new IR.PropRef<boolean>(["active"])
+  const key = (where: IR.BasicExpression<boolean>) =>
+    subsetOptionsToQueryKey("users", { where })
+
+  test("literal query delimiters cannot collide with extra filters", () => {
+    expect(key(eq(name, "Alice&active=eq.true"))).not.toEqual(
+      key(and(eq(name, "Alice"), eq(active, true)))
+    )
+  })
+
+  test("distinguishes NOT, OR branches, and IN list boundaries", () => {
+    expect(key(eq(name, "Alice"))).not.toEqual(key(not(eq(name, "Alice"))))
+    expect(key(or(eq(name, "Alice"), eq(active, true)))).not.toEqual(
+      key(or(eq(name, "Bob"), eq(active, true)))
+    )
+    expect(key(inArray(name, ["a,b", "c"]))).not.toEqual(
+      key(inArray(name, ["a", "b,c"]))
+    )
+  })
+
+  test("uses the merged IN request and omits unpushable OR groups", () => {
+    expect(
+      key(and(inArray(name, ["a", "b"]), inArray(name, ["b", "c"])))
+    ).toEqual(key(inArray(name, ["a", "b", "c"])))
+    expect(key(or(eq(name, "Alice"), eq(upper(name), "BOB")))).toEqual([
+      "users",
+    ])
+  })
+})

--- a/tests/query-once.test.ts
+++ b/tests/query-once.test.ts
@@ -548,6 +548,38 @@ describe("queryOnce PostgREST query generation", () => {
       ])
     })
 
+    test("aggregate with a negated logical group", async () => {
+      await queryOnce(
+        (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) =>
+              not(and(eq(user.active, true), ilike(user.name, "%ali%")))
+            )
+            .select(({ user }) => ({ totalUsers: count(user.id) })),
+        supabase
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=totalUsers:id.count()&or=(active.not.eq.true,name.not.ilike.%25ali%25)",
+      ])
+    })
+
+    test("aggregate rejects unsupported filters before making a request", async () => {
+      await expect(
+        queryOnce(
+          (q) =>
+            q
+              .from({ user: usersCollection })
+              .where(({ user }) =>
+                or(eq(user.active, true), eq(upper(user.name), "ALICE"))
+              )
+              .select(({ user }) => ({ totalUsers: count(user.id) })),
+          supabase
+        )
+      ).rejects.toThrow("fully pushable filters")
+      expect(mockFetch).not.toHaveBeenCalled()
+    })
+
     test("aggregate with NOT(name LIKE …)", async () => {
       await queryOnce(
         (q) =>

--- a/tests/query-once.test.ts
+++ b/tests/query-once.test.ts
@@ -9,9 +9,11 @@ import {
   eq,
   gt,
   gte,
+  ilike,
   inArray,
   isNull,
   length,
+  like,
   lower,
   lt,
   lte,
@@ -224,7 +226,7 @@ describe("queryOnce PostgREST query generation", () => {
       ])
     })
 
-    test.todo("OR: active = true OR id = 1", async () => {
+    test("OR: active = true OR id = 1", async () => {
       await queryOnce(
         (q) =>
           q
@@ -237,7 +239,7 @@ describe("queryOnce PostgREST query generation", () => {
       ])
     })
 
-    test.todo("nested AND/OR: active = true AND (id > 5 OR name = 'admin')", async () => {
+    test("nested AND/OR: active = true AND (id > 5 OR name = 'admin')", async () => {
       await queryOnce(
         (q) =>
           q
@@ -459,6 +461,104 @@ describe("queryOnce PostgREST query generation", () => {
       )
       expectFetchUrls(mockFetch, [
         "/rest/v1/users?select=totalUsers:id.count()&active=eq.true",
+      ])
+    })
+
+    // Only the aggregate / groupBy / having path reaches this package's own
+    // translator; every other query falls through to the collection loader.
+    test("aggregate with LIKE / ILIKE", async () => {
+      await queryOnce(
+        (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) => like(user.name, "%Ali%"))
+            .where(({ user }) => ilike(user.email, "%ali%"))
+            .select(({ user }) => ({ totalUsers: count(user.id) })),
+        supabase
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=totalUsers:id.count()&name=like.%25Ali%25&email=ilike.%25ali%25",
+      ])
+    })
+
+    test("aggregate with OR of ILIKEs", async () => {
+      await queryOnce(
+        (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) =>
+              or(ilike(user.name, "%ali%"), ilike(user.email, "%ali%"))
+            )
+            .select(({ user }) => ({ totalUsers: count(user.id) })),
+        supabase
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=totalUsers:id.count()&or=(name.ilike.%25ali%25,email.ilike.%25ali%25)",
+      ])
+    })
+
+    test("aggregate with nested AND/OR of ILIKEs", async () => {
+      await queryOnce(
+        (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) =>
+              and(
+                eq(user.active, true),
+                or(ilike(user.name, "%ali%"), ilike(user.email, "%ali%"))
+              )
+            )
+            .select(({ user }) => ({ totalUsers: count(user.id) })),
+        supabase
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=totalUsers:id.count()&active=eq.true&or=(name.ilike.%25ali%25,email.ilike.%25ali%25)",
+      ])
+    })
+
+    test("aggregate with an IN list inside an OR", async () => {
+      await queryOnce(
+        (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) =>
+              or(inArray(user.id, [1, 2, 3]), eq(user.active, true))
+            )
+            .select(({ user }) => ({ totalUsers: count(user.id) })),
+        supabase
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=totalUsers:id.count()&or=(id.in.(1,2,3),active.eq.true)",
+      ])
+    })
+
+    test("aggregate quotes values containing a comma", async () => {
+      await queryOnce(
+        (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) =>
+              or(ilike(user.name, "%a,b%"), eq(user.email, "x,y"))
+            )
+            .select(({ user }) => ({ totalUsers: count(user.id) })),
+        supabase
+      )
+      expectFetchUrls(mockFetch, [
+        '/rest/v1/users?select=totalUsers:id.count()&or=(name.ilike."%25a,b%25",email.eq."x,y")',
+      ])
+    })
+
+    test("aggregate with NOT(name LIKE …)", async () => {
+      await queryOnce(
+        (q) =>
+          q
+            .from({ user: usersCollection })
+            .where(({ user }) => not(like(user.name, "%Ali%")))
+            .select(({ user }) => ({ totalUsers: count(user.id) })),
+        supabase
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=totalUsers:id.count()&name=not.like.%25Ali%25",
       ])
     })
   })


### PR DESCRIPTION
NOTE: Claude Opus made this update.
 
* I needed simple text matching with `ilike`. I also needed `or` to check for a match on several columns. 
* New tests added to cover changes and all tests passing.