### PR TITLE
fix: merge duplicate PostgREST IN filters

### DIFF
--- a/src/functions.ts
+++ b/src/functions.ts
@@ -13,6 +13,37 @@ import {
 } from "@tanstack/db"
 import type { QueryClient, QueryMeta } from "@tanstack/query-core"
 
+const mergeInFilters = (filters: SimpleComparison[]) => {
+  const mergedFilters: SimpleComparison[] = []
+  const filtersByField = new Map<string, SimpleComparison>()
+
+  for (const filter of filters) {
+    const field = filter.field?.join(".")
+    if (filter.operator !== "in" || !field) {
+      mergedFilters.push(filter)
+      continue
+    }
+
+    const values = Array.isArray(filter.value) ? filter.value : [filter.value]
+    const existingFilter = filtersByField.get(field)
+    if (existingFilter) {
+      existingFilter.value = Array.from(
+        new Set([...(existingFilter.value as unknown[]), ...values])
+      )
+      continue
+    }
+
+    const mergedFilter = {
+      ...filter,
+      value: Array.from(new Set(values)),
+    }
+    mergedFilters.push(mergedFilter)
+    filtersByField.set(field, mergedFilter)
+  }
+
+  return mergedFilters
+}
+
 const buildQuery = (
   baseQuery: PostgrestFilterBuilder<any, any, any, any>,
   filter: SimpleComparison
@@ -145,7 +176,7 @@ export const supabaseQueryFn = async (
   }
 
   if (parsed.filters) {
-    ;[...parsed.filters, ...cursorFilters].forEach((filter) => {
+    mergeInFilters([...parsed.filters, ...cursorFilters]).forEach((filter) => {
       buildQuery(baseQuery, filter)
     })
   }

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -121,6 +121,30 @@ describe("PostgREST query generation", () => {
       expectFetchUrls(mockFetch, ["/rest/v1/users?select=*&id=in.(1,2,3)"])
     })
 
+    test("merges IN filters for the same column", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) =>
+            and(inArray(user.id, [1, 2]), inArray(user.id, [2, 3]))
+          )
+      )
+      expectFetchUrls(mockFetch, ["/rest/v1/users?select=*&id=in.(1,2,3)"])
+    })
+
+    test("keeps IN filters for different columns separate", async () => {
+      await queryResult((q) =>
+        q
+          .from({ user: usersCollection })
+          .where(({ user }) =>
+            and(inArray(user.id, [1, 2]), inArray(user.name, ["Alice", "Bob"]))
+          )
+      )
+      expectFetchUrls(mockFetch, [
+        "/rest/v1/users?select=*&id=in.(1,2)&name=in.(Alice,Bob)",
+      ])
+    })
+
     test("WHERE NOT(active = false)", async () => {
       await queryResult((q) =>
         q


### PR DESCRIPTION
Coalesces same-column positive IN filters before they reach postgrest-js, producing one deduplicated request parameter. Adds coverage for same-column merging and separate filters on different columns. Tests: pnpm test; pnpm typecheck.